### PR TITLE
feat: round 4 - v0.2.0, CI/CD exit codes, 30+ patterns, pattern overlap fix, operator UX

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -55,3 +55,52 @@ Log of key decisions made during ghosttype development. Each entry explains what
 **Decision:** For ChatGPT, attempt Keychain-backed decryption. If it fails (e.g., not running as the user, Keychain prompt denied), report the file path and metadata only rather than failing the whole scan.
 
 **Why:** Failing loudly on one tool would break scans on all other tools. Path-only results are still useful (evidence of the file's existence, count, timestamps).
+
+---
+
+## 2026-05-12 - Unredacted output by default
+
+**Decision:** Both `write_json` and `write_csv` default to `redact=False`. Use `--redact` to mask values.
+
+**Why:** Red team operators need to see credential values immediately without extra flags. DLP teams running automated pipelines can add `--redact` when generating shareable reports. The tool is run explicitly under authorization, so seeing plaintext is the expected default.
+
+---
+
+## 2026-05-12 - Known-example exclusion applied to both regex and heuristic
+
+**Decision:** `_KNOWN_EXAMPLE_VALUES` is checked in both the regex loop AND the heuristic filter, preventing well-known documentation examples (AKIAIOSFODNN7EXAMPLE, etc.) from ever appearing as findings.
+
+**Why:** These values appear in AWS docs, tutorial repos, and test fixtures worldwide. Reporting them would be noise in any real scan. The exclusion set is maintained in code; future additions can reference official doc sources.
+
+---
+
+## 2026-05-12 - Entropy threshold 3.0 bits/char for heuristic matches
+
+**Decision:** Heuristic (medium-confidence) matches are filtered if Shannon entropy < 3.0 bits/char.
+
+**Why:** Industry standard from gitleaks and detect-secrets. Real API keys and passwords cluster above 3.5; common placeholder strings cluster below 3.0. Raises the signal-to-noise ratio for medium-confidence findings significantly.
+
+---
+
+## 2026-05-12 - Exit code 1 when findings present
+
+**Decision:** `ghosttype scan` exits with code 1 if any findings are discovered, 0 if clean.
+
+**Why:** Enables CI/CD integration. Operators can add `ghosttype scan --quiet` as a pre-commit or CI step and gate on non-zero exit. Standard convention for security scanner CLIs (truffleHog, gitleaks both do this).
+
+---
+
+## 2026-05-12 - Severity field on Finding
+
+**Decision:** Each Finding has a `severity` field: `critical` (highest-value keys like AWS, OpenAI, private keys), `high` (other regex matches), `medium` (heuristic).
+
+**Why:** Operators need to triage. Critical findings warrant immediate action; medium findings warrant review. Severity is based on credential type, not detection confidence - a Vault token (critical) is more dangerous than a Doppler token (high) regardless of how it was detected.
+
+---
+
+## 2026-05-13 - Heuristic cross-pattern deduplication via captured_values set
+
+**Decision:** `scan_text` maintains a `captured_values` set that grows as heuristics fire, preventing later heuristics from re-reporting a value already captured by an earlier heuristic.
+
+**Why:** Without this, `heuristic_aws_secret` and `heuristic_generic_secret` both matched the same 40-char AWS secret key value when `ACCESS_KEY` appeared in `SECRET_ACCESS_KEY`. The `captured_values` set is updated after each heuristic match, so subsequent patterns skip already-seen values regardless of pattern type.
+

--- a/ghosttype/cli.py
+++ b/ghosttype/cli.py
@@ -34,7 +34,7 @@ def cli() -> None:
 @cli.command()
 def version() -> None:
     """Print version information."""
-    console.print("[bold cyan]ghosttype[/bold cyan] [dim]v0.1.0[/dim]")
+    console.print("[bold cyan]ghosttype[/bold cyan] [dim]v0.2.0[/dim]")
     console.print("[dim]credential scanner for AI tool conversation history[/dim]")
 
 
@@ -158,7 +158,7 @@ def _print_banner() -> None:
     console.print(_BANNER, highlight=False)
     console.print(
         "  [dim]credential scanner for AI tool conversation history[/dim]"
-        "  [dim red]authorized use only[/dim red]  [dim]v0.1.0[/dim]\n"
+        "  [dim red]authorized use only[/dim red]  [dim]v0.2.0[/dim]\n"
     )
 
 

--- a/ghosttype/cli.py
+++ b/ghosttype/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections import Counter
 from pathlib import Path
 
@@ -58,6 +59,7 @@ def version() -> None:
 )
 @click.option("--allow-list", default=None, type=click.Path(exists=True), help="Path to file with known-safe values to suppress (one per line)")
 @click.option("--stats-only", is_flag=True, default=False, help="Print summary statistics only, not full findings table")
+@click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress banner and progress messages (for scripting)")
 def scan(
     tool: str | None,
     fmt: str,
@@ -68,15 +70,24 @@ def scan(
     min_confidence: str,
     allow_list: str | None,
     stats_only: bool,
+    quiet: bool,
 ) -> None:
     """Scan AI tool conversation files for credentials and secrets."""
-    _print_banner()
+    if not quiet:
+        _print_banner()
     out_dir = Path(output)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    console.print(f"[bold]ghosttype[/bold] scanning... output -> [cyan]{out_dir}[/cyan]")
+    if not quiet:
+        console.print(f"[bold]ghosttype[/bold] scanning... output -> [cyan]{out_dir}[/cyan]")
 
     orch = Orchestrator(context_window=context_window)
+
+    if not quiet:
+        from ghosttype.scanners import SCANNERS
+        active = [s for s in SCANNERS if (not tool or s.name == tool) and s.is_available()]
+        console.print(f"[dim]Scanning {len(active)} tool(s): {', '.join(s.name for s in active)}[/dim]")
+
     findings = orch.run(tool_filter=tool)
     if min_confidence == "high":
         findings = [f for f in findings if f.confidence == "high"]
@@ -92,14 +103,15 @@ def scan(
                     allowed.add(line)
         suppressed_count = len([f for f in findings if f.secret_value in allowed])
         findings = [f for f in findings if f.secret_value not in allowed]
-        if allowed:
+        if allowed and not quiet:
             console.print(f"[dim]Allow-list suppressed {suppressed_count} value(s)[/dim]")
 
-    console.print(f"[dim]Scanned {orch.files_scanned} conversation file(s)[/dim]")
-    if not findings:
-        console.print("[yellow]No findings.[/yellow]")
-    else:
-        console.print(f"[green]{len(findings)} finding(s) discovered.[/green]")
+    if not quiet:
+        console.print(f"[dim]Scanned {orch.files_scanned} conversation file(s)[/dim]")
+        if not findings:
+            console.print("[yellow]No findings.[/yellow]")
+        else:
+            console.print(f"[green]{len(findings)} finding(s) discovered.[/green]")
 
     if findings:
         if fmt in ("json", "both"):
@@ -108,14 +120,19 @@ def scan(
             write_csv(findings, out_dir / "findings.csv", redact=redact)
         if copy_sources:
             copy_sources_fn(findings, out_dir / "sources")
-            console.print(f"[dim]Source files copied to {out_dir / 'sources'}[/dim]")
+            if not quiet:
+                console.print(f"[dim]Source files copied to {out_dir / 'sources'}[/dim]")
     else:
-        console.print("[dim]No output files written.[/dim]")
+        if not quiet:
+            console.print("[dim]No output files written.[/dim]")
 
     if not stats_only:
         _print_summary(findings, orch.files_scanned)
     else:
         _print_stats_only(findings, orch.files_scanned)
+
+    if findings:
+        sys.exit(1)  # non-zero exit when credentials found - enables CI use
 
 
 @cli.command("list-tools")

--- a/ghosttype/patterns.py
+++ b/ghosttype/patterns.py
@@ -9,8 +9,9 @@ from ghosttype.models import PatternMatch
 # Layer 1: known credential formats (confidence: high)
 _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("aws_access_key", re.compile(r"(?<![A-Z0-9])(AKIA[0-9A-Z]{16})(?![A-Z0-9])")),
-    # OpenAI tokens: classic sk- and newer sk-proj- formats
-    ("openai_token", re.compile(r"\b(sk-(?:proj-)?[a-zA-Z0-9\-_]{20,})\b")),
+    # OpenAI tokens: classic sk- and newer sk-proj- formats.
+    # Negative lookahead (?!ant-) prevents overlap with anthropic_key (sk-ant-...).
+    ("openai_token", re.compile(r"\b(sk-(?!ant-)(?:proj-)?[a-zA-Z0-9\-_]{20,})\b")),
     ("github_pat_classic", re.compile(r"\b(ghp_[a-zA-Z0-9]{36,})\b")),
     ("github_pat_fine", re.compile(r"\b(github_pat_[a-zA-Z0-9_]{82})\b")),
     ("anthropic_key", re.compile(r"\b(sk-ant-[a-zA-Z0-9\-]{20,})\b")),

--- a/ghosttype/patterns.py
+++ b/ghosttype/patterns.py
@@ -30,7 +30,7 @@ _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     (
         "connection_string",
         re.compile(
-            r"((?:postgresql|mysql|mongodb|redis)://[^\s\"\'<>\n]{8,})"
+            r"((?:postgresql|mysql|mongodb|redis)://[^\s\"\'<>`\n]{8,})"
         ),
     ),
     # Stripe keys

--- a/ghosttype/patterns.py
+++ b/ghosttype/patterns.py
@@ -65,6 +65,14 @@ _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("gcp_api_key",         re.compile(r"\b(AIzaSy[a-zA-Z0-9_-]{33})\b")),
     # AWS STS temporary tokens (ASIA prefix)
     ("aws_sts_token",       re.compile(r"(?<![A-Z0-9])(ASIA[0-9A-Z]{16})(?![A-Z0-9])")),
+    # Docker Hub personal access tokens
+    ("dockerhub_token",     re.compile(r"\b(dckr_pat_[a-zA-Z0-9_-]{20,})\b")),
+    # Pulumi access tokens
+    ("pulumi_token",        re.compile(r"\b(pul-[a-zA-Z0-9]{40})\b")),
+    # Doppler service tokens
+    ("doppler_token",       re.compile(r"\b(dp\.st\.[a-zA-Z0-9]{43})\b")),
+    # PyPI API tokens
+    ("pypi_token",          re.compile(r"\b(pypi-[a-zA-Z0-9_-]{100,})\b")),
 ]
 
 # Layer 2: variable-name context signals (confidence: medium)
@@ -192,6 +200,13 @@ _KNOWN_EXAMPLE_VALUES: frozenset[str] = frozenset({
     "dapi1234567890abcdef1234567890abcdef",
     "npm_1234567890abcdefghijklmnopqrstuvwxyz",
     "123456789:AABBccDDeeffGGhhIIjjKKllMMnnOOppQQrr",
+    # Common test connection strings
+    "postgresql://user:password@localhost:5432/mydb",
+    "postgresql://user:password@localhost/mydb",
+    "mysql://user:password@localhost:3306/mydb",
+    "mongodb://user:password@localhost:27017/mydb",
+    # GCP API key test value
+    "AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567",
 })
 
 

--- a/ghosttype/patterns.py
+++ b/ghosttype/patterns.py
@@ -61,6 +61,10 @@ _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("github_oauth_token", re.compile(r"\b(gho_[a-zA-Z0-9]{36})\b")),
     # GitHub refresh tokens
     ("github_refresh_token", re.compile(r"\b(ghr_[a-zA-Z0-9]{76})\b")),
+    # GCP API keys (browser/server keys)
+    ("gcp_api_key",         re.compile(r"\b(AIzaSy[a-zA-Z0-9_-]{33})\b")),
+    # AWS STS temporary tokens (ASIA prefix)
+    ("aws_sts_token",       re.compile(r"(?<![A-Z0-9])(ASIA[0-9A-Z]{16})(?![A-Z0-9])")),
 ]
 
 # Layer 2: variable-name context signals (confidence: medium)
@@ -164,6 +168,8 @@ _KNOWN_EXAMPLE_VALUES: frozenset[str] = frozenset({
     # AWS documentation canonical example credentials
     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
     "AKIAIOSFODNN7EXAMPLE",
+    # AWS STS docs canonical example token prefix
+    "ASIAIOSFODNN7EXAMPLE",
     # Famous test passwords
     "hunter2supersecretvalue",
     "hunter2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ghosttype"
-version = "0.1.0"
+version = "0.2.0"
 description = "Local forensic scanner for AI tool conversation credentials"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,7 +82,7 @@ def test_version_command():
     result = runner.invoke(cli, ["version"])
     assert result.exit_code == 0
     assert "ghosttype" in result.output
-    assert "v0.1.0" in result.output
+    assert "v0.2.0" in result.output
     assert "credential scanner" in result.output
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ def test_scan_writes_json_by_default(tmp_path, monkeypatch):
         MockOrch.return_value.run.return_value = [fake_finding]
         MockOrch.return_value.files_scanned = 1
         result = runner.invoke(cli, ["scan", "--output", str(tmp_path / "report")])
-    assert result.exit_code == 0
+    assert result.exit_code == 1  # non-zero when findings are present (CI/CD behavior)
     assert (tmp_path / "report" / "findings.json").exists()
     assert (tmp_path / "report" / "findings.csv").exists()
 
@@ -119,7 +119,7 @@ def test_scan_with_allow_list(tmp_path):
         MockOrch.return_value.files_scanned = 2
         result = runner.invoke(cli, ["scan", "--output", str(tmp_path / "report"), "--allow-list", str(allow_list_file)])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1  # non-zero when findings remain after suppression
     assert "Allow-list suppressed" in result.output
 
 
@@ -143,7 +143,7 @@ def test_scan_with_stats_only(tmp_path):
         MockOrch.return_value.files_scanned = 1
         result = runner.invoke(cli, ["scan", "--output", str(tmp_path / "report"), "--stats-only"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1  # non-zero when findings are present (CI/CD behavior)
     # With --stats-only, we should see the stats breakdown (By Type, By Tool)
     assert "By Type" in result.output or "By Tool" in result.output
     # Should still have findings summary

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -37,7 +37,7 @@ def test_detects_jwt():
 
 
 def test_detects_connection_string():
-    text = "db = connect('postgresql://user:password@localhost:5432/mydb')"
+    text = "db = connect('postgresql://admin:Tr0ub4dor@prod-db.corp.example.com:5432/appdb')"
     matches = scan_text(text)
     assert any(m.secret_type == "connection_string" for m in matches)
 
@@ -163,7 +163,7 @@ def test_detects_github_refresh_token():
 
 
 def test_detects_gcp_api_key():
-    text = "MAPS_KEY=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567"
+    text = "MAPS_KEY=AIzaSyXp9mK3rT8nQ2vL5wJ4eB7uF1cG6hD0sYZ"  # 6+33=39 chars
     matches = scan_text(text)
     assert any(m.secret_type == "gcp_api_key" for m in matches)
 
@@ -179,3 +179,35 @@ def test_aws_sts_example_value_excluded():
     text = "AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE"
     matches = scan_text(text)
     assert not any(m.secret_type == "aws_sts_token" for m in matches)
+
+
+def test_detects_dockerhub_token():
+    text = "DOCKER_TOKEN=dckr_pat_AbCdEfGhIjKlMnOpQrStUvWx"
+    matches = scan_text(text)
+    assert any(m.secret_type == "dockerhub_token" for m in matches)
+
+
+def test_detects_pulumi_token():
+    text = "PULUMI_ACCESS_TOKEN=pul-" + "a" * 40
+    matches = scan_text(text)
+    assert any(m.secret_type == "pulumi_token" for m in matches)
+
+
+def test_detects_doppler_token():
+    text = "DOPPLER_TOKEN=dp.st." + "a" * 43
+    matches = scan_text(text)
+    assert any(m.secret_type == "doppler_token" for m in matches)
+
+
+def test_test_connection_string_excluded():
+    """Standard localhost test connection strings should not be reported."""
+    text = "postgresql://user:password@localhost:5432/mydb"
+    matches = scan_text(text)
+    assert not any(m.secret_type == "connection_string" for m in matches)
+
+
+def test_real_connection_string_still_detected():
+    """Production-looking connection strings should still be detected."""
+    text = "postgresql://admin:Tr0ub4dor@prod-db.company.internal:5432/appdb"
+    matches = scan_text(text)
+    assert any(m.secret_type == "connection_string" for m in matches)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -211,3 +211,19 @@ def test_real_connection_string_still_detected():
     text = "postgresql://admin:Tr0ub4dor@prod-db.company.internal:5432/appdb"
     matches = scan_text(text)
     assert any(m.secret_type == "connection_string" for m in matches)
+
+
+def test_anthropic_key_not_classified_as_openai_token():
+    """sk-ant- prefixed keys must only match anthropic_key, not openai_token."""
+    text = "API_KEY=sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890abc"
+    matches = scan_text(text)
+    types = [m.secret_type for m in matches]
+    assert "anthropic_key" in types
+    assert "openai_token" not in types
+
+
+def test_openai_token_still_detected_after_lookahead():
+    """Negative lookahead for ant- must not break regular sk- OpenAI token detection."""
+    text = "OPENAI_KEY=sk-abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJ12"
+    matches = scan_text(text)
+    assert any(m.secret_type == "openai_token" for m in matches)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -160,3 +160,22 @@ def test_detects_github_refresh_token():
     text = "GH_REFRESH=ghr_" + "A" * 76
     matches = scan_text(text)
     assert any(m.secret_type == "github_refresh_token" for m in matches)
+
+
+def test_detects_gcp_api_key():
+    text = "MAPS_KEY=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567"
+    matches = scan_text(text)
+    assert any(m.secret_type == "gcp_api_key" for m in matches)
+
+
+def test_detects_aws_sts_token():
+    text = "AWS_ACCESS_KEY_ID=ASIAIOSFODNN7TESTKEY"
+    matches = scan_text(text)
+    assert any(m.secret_type == "aws_sts_token" for m in matches)
+
+
+def test_aws_sts_example_value_excluded():
+    """ASIAIOSFODNN7EXAMPLE is the AWS docs STS example and must be suppressed."""
+    text = "AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE"
+    matches = scan_text(text)
+    assert not any(m.secret_type == "aws_sts_token" for m in matches)


### PR DESCRIPTION
## Summary

- **v0.2.0** bump
- **Critical bug fix**: `openai_token` regex overlapped with Anthropic keys (`sk-ant-`). Added negative lookahead `(?!ant-)` - same Anthropic key was being reported as BOTH `anthropic_key` and `openai_token`
- **Exit code 1** when findings present (0 = clean) - enables `ghosttype scan --quiet` in CI/CD pipelines
- **4 new patterns**: Docker Hub (`dckr_pat_`), Pulumi (`pul-`), Doppler (`dp.st.`), PyPI (`pypi-`)
- **GCP API key** (`AIzaSy...`) and **AWS STS tokens** (`ASIA...`) from round 3
- **Known-example exclusions** for localhost connection strings, GCP API key test values
- **Backtick fix** in connection_string pattern (markdown code blocks no longer include trailing backtick in captured value)
- **`--quiet` / `-q`** flag suppresses banner and progress (for scripting)
- **Progress display** shows which tools are being scanned
- **`ghosttype version`** command
- **Rich stats breakdown** (by type + by tool) in `--stats-only` mode
- **`--allow-list`** file for suppressing reviewed FPs
- **DECISIONS.md** updated with all architectural decisions from rounds 2-4
- **90 tests** - regression coverage for all new patterns and the overlap fix

## Test Plan

- [ ] `pytest -v` - 90 tests pass
- [ ] `ghosttype scan --quiet --output /tmp/x; echo $?` - exits 1 when findings
- [ ] `ghosttype scan --quiet --output /tmp/x; echo $?` on clean machine - exits 0
- [ ] Anthropic key `sk-ant-...` reports only `anthropic_key`, not `openai_token`
- [ ] `ghosttype version` - shows v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)