### PR TITLE
docs+feat: ARCHITECTURE.md rewrite, stdout piping, 93 tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,54 +2,58 @@
 
 ## Overview
 
-ghosttype is a CLI tool with a plugin-style scanner architecture. Each target AI tool has its own scanner module that knows how to find and read that tool's conversation files. A shared pattern engine runs on the extracted text. A thin orchestrator ties them together.
+ghosttype is a CLI tool with a plugin-style scanner architecture. Each target AI tool has its own scanner module that knows how to find and read that tool's conversation files. A shared pattern engine (30 regex patterns + 10 heuristic patterns) runs on the extracted text. A thin orchestrator ties scanners, patterns, and reporting together.
+
+## Directory layout
 
 ```
 ghosttype/
-├── cli.py              # click CLI entry point
-├── scanner.py          # orchestrator: discovers -> extracts -> detects -> reports
-├── patterns.py         # compiled regex + heuristic pattern registry
-├── report.py           # CSV + JSON writer
+├── cli.py                # click CLI entry point
+├── scanner.py            # Orchestrator: discovers -> filters by max_age_days -> extracts -> detects -> reports
+├── patterns.py           # 30 regex + 10 heuristic pattern registry; entropy filter; deduplication
+├── models.py             # dataclasses: ConversationRecord, TextChunk, PatternMatch, Finding
+├── report.py             # CSV + JSON writer; source file copier
 └── scanners/
-    ├── base.py         # Scanner ABC
-    ├── cursor.py       # Cursor IDE (state.vscdb SQLite)
-    ├── chatgpt.py      # ChatGPT desktop (.data files, macOS Keychain-backed)
-    ├── codex.py        # Codex CLI (~/.codex/ SQLite)
-    ├── claude.py       # Claude desktop app (SQLite)
-    └── claude_code.py  # Claude Code CLI (~/.claude/projects/ JSONL)
+    ├── base.py           # Scanner ABC with _base_path, is_available(), discover(), extract_text()
+    ├── __init__.py       # SCANNERS registry
+    ├── claude_code.py    # Claude Code CLI (~/.claude/projects/**/*.jsonl + history.jsonl + tasks/**/*.json)
+    ├── cursor.py         # Cursor IDE (globalStorage/ + workspaceStorage/*/)
+    ├── codex.py          # Codex CLI (~/.codex/ SQLite)
+    ├── chatgpt.py        # ChatGPT desktop (.data files, macOS Keychain-backed AES-128-CBC)
+    └── claude.py         # Claude desktop (stub; SQLite under ~/Library/Application Support/Claude/)
 ```
-
----
 
 ## Data flow
 
 ```
-CLI invocation
+CLI invocation (--tool, --format, --output, --max-age-days, etc.)
     |
     v
-Orchestrator (scanner.py)
-    |-- iterates registered scanner plugins
-    |       |
-    |       v
-    |   scanner.discover() -> list[Path | ConversationRecord]
-    |       |
-    |       v
-    |   scanner.extract_text(record) -> list[TextChunk]
+Orchestrator.run(tool_filter)
+    |-- for each registered scanner:
+    |       |-- if available: scanner.discover() -> list[ConversationRecord]
+    |       |-- filter by max_age_days (if set)
+    |       |-- for each record: scanner.extract_text() -> list[TextChunk]
+    |       |-- for each chunk: pattern engine scans text
     |
     v
-Pattern engine (patterns.py)
-    |-- run regex patterns against each chunk
-    |-- run heuristic patterns against each chunk
-    |-- deduplicate by (value, file_path)
+Pattern engine (scan_text)
+    |-- run 30 regex patterns (high confidence)
+    |-- run 10 heuristic patterns (medium confidence)
+    |-- filter by entropy threshold (3.0 bits/char)
+    |-- filter known example values
+    |-- deduplicate: (secret_value, file_path, secret_type)
     |
     v
-Report writer (report.py)
-    |-- write findings.json
-    |-- write findings.csv
-    |-- write summary to stdout
+Finding list (sorted by severity)
+    |
+    v
+Report writer
+    |-- JSON: findings.json (optionally redacted)
+    |-- CSV: findings.csv (optionally redacted)
+    |-- Sources: copy referenced files to sources/ (if --copy-sources)
+    |-- Stdout: (if --output -)
 ```
-
----
 
 ## Scanner interface (base.py)
 
@@ -57,12 +61,17 @@ Each scanner implements the `Scanner` ABC:
 
 ```python
 class Scanner(ABC):
-    name: str                    # tool identifier, e.g. "cursor"
-    display_name: str            # human label, e.g. "Cursor IDE"
+    name: str                            # tool identifier, e.g. "cursor"
+    display_name: str                    # human label, e.g. "Cursor IDE"
 
+    @property
     @abstractmethod
+    def _base_path(self) -> Path:
+        """Root path for this tool's data directory."""
+
     def is_available(self) -> bool:
-        """Return True if this tool's data directory exists on the current machine."""
+        """Return True if this tool's data directory exists."""
+        return self._base_path.exists()
 
     @abstractmethod
     def discover(self) -> list[ConversationRecord]:
@@ -73,72 +82,105 @@ class Scanner(ABC):
         """Extract plain text chunks from a conversation record."""
 ```
 
-`ConversationRecord` carries: `source_path`, `tool`, `conversation_id`, `created_at`, `raw` (bytes or dict).
+`ConversationRecord` carries: `source_path`, `tool`, `conversation_id`, `created_at`, `raw`.
 
-`TextChunk` carries: `text`, `position`, `record` (back-reference).
-
----
+`TextChunk` carries: `text`, `position` (line number or row:offset), `record` (back-reference).
 
 ## Pattern engine (patterns.py)
 
-Two layers:
+### Layer 1: Regex patterns (30 types, confidence: high)
 
-**Layer 1 - Regex (high confidence)**
+Known credential formats with exact structure:
 
-Known credential formats with named groups:
+**AWS:** aws_access_key (AKIA...), aws_sts_token (ASIA...)
 
-```python
-PATTERNS = {
-    "aws_access_key":      r'(?P<val>AKIA[0-9A-Z]{16})',
-    "aws_secret_key":      r'(?P<val>[0-9a-zA-Z/+]{40})',  # context-gated
-    "openai_token":        r'(?P<val>sk-[a-zA-Z0-9]{48,})',
-    "github_pat_classic":  r'(?P<val>ghp_[a-zA-Z0-9]{36})',
-    "github_pat_fine":     r'(?P<val>github_pat_[a-zA-Z0-9_]{82})',
-    "anthropic_key":       r'(?P<val>sk-ant-[a-zA-Z0-9\-]{95,})',
-    "gcp_service_account": r'(?P<val>[a-zA-Z0-9\-]+@[a-zA-Z0-9\-]+\.iam\.gserviceaccount\.com)',
-    "private_key_pem":     r'(?P<val>-----BEGIN [A-Z ]+PRIVATE KEY-----)',
-    "jwt":                 r'(?P<val>eyJ[A-Za-z0-9\-_]+\.eyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+)',
-    "connection_string":   r'(?P<val>(?:postgresql|mysql|mongodb|redis)://[^\s"\'<>]+)',
-    "generic_api_key":     r'(?i)(?P<val>[a-zA-Z0-9]{32,64})',  # heuristic-gated
-}
+**GitHub:** github_pat_classic (ghp_...), github_pat_fine (github_pat_...), github_app_token (ghs_...), github_user_token (ghu_...), github_oauth_token (gho_...), github_refresh_token (ghr_...)
+
+**OpenAI & Anthropic:** openai_token (sk-proj-..., sk-...), anthropic_key (sk-ant-...)
+
+**Cloud & DevOps:** gcp_service_account, gcp_api_key, stripe_secret_key, stripe_test_key, slack_token, vault_token, sendgrid_key
+
+**Tools & Services:** linear_api_key, databricks_token, npm_token, telegram_bot_token, huggingface_token, digitalocean_token, dockerhub_token, pulumi_token, doppler_token, pypi_token
+
+**Infrastructure:** private_key_pem, jwt, connection_string
+
+### Layer 2: Heuristic patterns (10 types, confidence: medium)
+
+Variable-name context signals that unlock loose value matching:
+
+1. heuristic_api_key: api_key=, apikey=, etc.
+2. heuristic_password: password=, passwd=, pwd=
+3. heuristic_secret_key: secret_key=, secret=
+4. heuristic_token: access_token=, auth_token=, bearer=
+5. heuristic_private_key: private_key=
+6. heuristic_aws_secret: AWS_SECRET_ACCESS_KEY= (40-char base64)
+7. heuristic_jwt_secret: JWT_SECRET=, SIGNING_KEY=, TOKEN_SECRET=
+8. heuristic_azure_secret: AZURE_CLIENT_SECRET=, storage_account_key=
+9. heuristic_generic_secret: api-secret=, auth-key=, private-token=
+10. heuristic_supabase_key: SUPABASE_SERVICE_ROLE_KEY=, SUPABASE_ANON_KEY=
+
+### False positive reduction
+
+- **Entropy filter:** Matches must have >= 3.0 bits/char (filters random garbage)
+- **Placeholder filter:** Reject matches starting with: your[-_]?(?:key|secret|api|password|credential), fake[-_]?, test[-_]?, example[-_]?, placeholder[-_]?, demo[-_]?, dummy[-_]?, sample[-_]?
+- **Known-examples exclusion:** Hardcoded set of common documentation examples and generated test values
+
+### Deduplication
+
+Two-level dedup per text chunk:
+- Regex layer: track (secret_type, value) in seen set
+- Heuristic layer: track captured_values to avoid duplicate heuristic matches
+
+Orchestrator-level dedup: (secret_value, file_path, secret_type)
+
+## Finding severity
+
+Findings are classified by severity based on secret type:
+
+**Critical:** aws_access_key, anthropic_key, openai_token, github_pat_classic, github_pat_fine, github_app_token, stripe_secret_key, private_key_pem, vault_token, heuristic_aws_secret, heuristic_supabase_key
+
+**High:** (reserved for future expansion)
+
+**Medium:** all others (heuristic patterns, less-sensitive token types)
+
+Severity filters CLI output and report generation.
+
+## CLI options
+
+All scan options:
+
+```bash
+--tool {cursor|chatgpt|codex|claude|claude_code}  # Scan only this tool
+--format {json|csv|both}                          # Output format (default: both)
+--output OUTPUT                                   # Output directory or - for stdout (default: ./ghosttype_report)
+--redact                                          # Redact secret values in files
+--context-window N                                # Context chars around match (default: 200)
+--copy-sources                                    # Copy source files to output/sources/
+--min-confidence {high|medium}                    # Filter by confidence (default: medium)
+--allow-list PATH                                 # Suppress known-safe values (one per line)
+--stats-only                                      # Print stats only, no findings table
+--quiet / -q                                      # Suppress banner and progress
+--max-age-days N                                  # Only scan files modified within last N days
 ```
 
-**Layer 2 - Heuristic (medium confidence)**
+Special output modes:
 
-Variable name context signals that unlock loose value matching:
+- `--output ./dir`: Write findings.json, findings.csv, sources/ to ./dir
+- `--output -`: Write findings JSON to stdout only (for piping to jq, etc.)
 
-```python
-HEURISTIC_SIGNALS = [
-    r'(?i)(?:api[_\-]?key|apikey)\s*[=:]\s*["\']?(?P<val>[^\s"\']{8,})',
-    r'(?i)(?:password|passwd|pwd)\s*[=:]\s*["\']?(?P<val>[^\s"\']{6,})',
-    r'(?i)(?:secret[_\-]?key|secret)\s*[=:]\s*["\']?(?P<val>[^\s"\']{8,})',
-    r'(?i)(?:access[_\-]?token|auth[_\-]?token|bearer)\s*[=:]\s*["\']?(?P<val>[^\s"\']{8,})',
-    r'(?i)(?:private[_\-]?key)\s*[=:]\s*["\']?(?P<val>[^\s"\']{8,})',
-]
-```
+## Scanner coverage
 
----
-
-## Report output
-
-All findings are written to the output directory (default: `./ghosttype_report/`):
-
-```
-ghosttype_report/
-├── findings.json        # full detail, secret values in plaintext
-├── findings.csv         # tabular, secret values redacted by default (--no-redact to disable)
-└── sources/             # copies of source conversation files referenced in findings
-    └── <tool>/<hash>.{jsonl,sqlite,data,...}
-```
-
-The `sources/` copy allows offline review and is what red teamers hand off as loot evidence and what blue teamers hand to the credential rotation team.
-
----
+| Scanner | Data Sources | Format |
+|---------|--------------|--------|
+| claude_code | ~/.claude/projects/**/*.jsonl + history.jsonl + tasks/**/*.json | JSONL + JSON |
+| cursor | ~/.config/Cursor/globalStorage/state.vscdb + workspaceStorage/*/state.vscdb | SQLite |
+| codex | ~/.codex/state_5.sqlite + logs_2.sqlite | SQLite |
+| chatgpt | ~/Library/Application Support/com.openai.chat/conversations-v3-*/*.data | Binary (AES-128-CBC, Keychain-backed) |
+| claude | ~/Library/Application Support/Claude/ (stub implementation) | SQLite |
 
 ## Adding a new scanner
 
 1. Create `ghosttype/scanners/<toolname>.py`
-2. Implement the `Scanner` ABC
-3. Register in `ghosttype/scanners/__init__.py`
-
-No changes needed to the orchestrator or pattern engine.
+2. Implement the Scanner ABC: define `name`, `display_name`, `_base_path` property, and override `discover()` and `extract_text()`
+3. Register in `ghosttype/scanners/__init__.py` by adding an instance to the SCANNERS list
+4. No changes needed to orchestrator, patterns, or CLI

--- a/ghosttype/cli.py
+++ b/ghosttype/cli.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import sys
+import tempfile
 from collections import Counter
 from pathlib import Path
 
@@ -46,7 +48,7 @@ def version() -> None:
     help="Scan only this tool",
 )
 @click.option("--format", "fmt", default="both", type=click.Choice(["json", "csv", "both"]), show_default=True)
-@click.option("--output", default="./ghosttype_report", show_default=True, help="Output directory")
+@click.option("--output", default="./ghosttype_report", show_default=True, help="Output directory or - for stdout (JSON only)")
 @click.option("--redact", is_flag=True, default=False, help="Redact secret values in output files")
 @click.option("--context-window", default=200, show_default=True, help="Context characters around each match")
 @click.option("--copy-sources", is_flag=True, default=False, help="Copy source conversation files to output dir (may contain sensitive content)")
@@ -75,12 +77,18 @@ def scan(
     max_age_days: int | None,
 ) -> None:
     """Scan AI tool conversation files for credentials and secrets."""
-    if not quiet:
-        _print_banner()
-    out_dir = Path(output)
-    out_dir.mkdir(parents=True, exist_ok=True)
+    stdout_mode = output == "-"
 
-    if not quiet:
+    if not quiet and not stdout_mode:
+        _print_banner()
+
+    if stdout_mode:
+        out_dir = Path(tempfile.mkdtemp())
+    else:
+        out_dir = Path(output)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not quiet and not stdout_mode:
         console.print(f"[bold]ghosttype[/bold] scanning... output -> [cyan]{out_dir}[/cyan]")
 
     orch = Orchestrator(context_window=context_window, max_age_days=max_age_days)
@@ -116,22 +124,42 @@ def scan(
             console.print(f"[green]{len(findings)} finding(s) discovered.[/green]")
 
     if findings:
-        if fmt in ("json", "both"):
-            write_json(findings, out_dir / "findings.json", redact=redact)
-        if fmt in ("csv", "both"):
-            write_csv(findings, out_dir / "findings.csv", redact=redact)
-        if copy_sources:
-            copy_sources_fn(findings, out_dir / "sources")
-            if not quiet:
-                console.print(f"[dim]Source files copied to {out_dir / 'sources'}[/dim]")
+        if stdout_mode:
+            # Write JSON to stdout only
+            data = [
+                {
+                    "tool": f.tool,
+                    "secret_type": f.secret_type,
+                    "severity": f.severity,
+                    "secret_value": "***REDACTED***" if redact else f.secret_value,
+                    "file_path": str(f.file_path),
+                    "position": f.position,
+                    "confidence": f.confidence,
+                    "context": f.context,
+                    "discovered_at": f.discovered_at.isoformat(),
+                }
+                for f in findings
+            ]
+            sys.stdout.write(json.dumps(data, indent=2))
+            sys.stdout.write("\n")
+        else:
+            if fmt in ("json", "both"):
+                write_json(findings, out_dir / "findings.json", redact=redact)
+            if fmt in ("csv", "both"):
+                write_csv(findings, out_dir / "findings.csv", redact=redact)
+            if copy_sources:
+                copy_sources_fn(findings, out_dir / "sources")
+                if not quiet:
+                    console.print(f"[dim]Source files copied to {out_dir / 'sources'}[/dim]")
     else:
-        if not quiet:
+        if not quiet and not stdout_mode:
             console.print("[dim]No output files written.[/dim]")
 
-    if not stats_only:
-        _print_summary(findings, orch.files_scanned)
-    else:
-        _print_stats_only(findings, orch.files_scanned)
+    if not stdout_mode:
+        if not stats_only:
+            _print_summary(findings, orch.files_scanned)
+        else:
+            _print_stats_only(findings, orch.files_scanned)
 
     if findings:
         sys.exit(1)  # non-zero exit when credentials found - enables CI use


### PR DESCRIPTION
## Summary

- **ARCHITECTURE.md** fully rewritten: documents 40 patterns, all scanners, severity classification, CLI options, scanner coverage table
- **`--output -`** for stdout JSON: `ghosttype scan --format json --output - --quiet | jq '.[] | select(.severity == "critical")'`
- Stdout mode suppresses all decorative output for clean piping

🤖 Generated with [Claude Code](https://claude.com/claude-code)