### PR TITLE
Update repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ ghosttype doctor
 ## Quick start
 
 ```bash
-git clone https://github.com/p4gs/ghosttype
+git clone https://github.com/xFreed0m/ghosttype
 cd ghosttype
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"


### PR DESCRIPTION
My previous contribution resulted in the README's quick start instructions to use my fork's URL, not the original GitHub URL for the project