### PR TITLE
Apply formatting fixes and handle Linux keychain errors gracefully

### DIFF
--- a/ghosttype/cli.py
+++ b/ghosttype/cli.py
@@ -15,6 +15,8 @@ from rich.table import Table
 from ghosttype.models import Finding
 from ghosttype.report import (
     copy_sources as copy_sources_fn,
+)
+from ghosttype.report import (
     finding_to_dict,
     write_csv,
     write_json,
@@ -285,7 +287,7 @@ def scan(
     suppressed_count = 0
     if allow_list:
         allowed: set[str] = set()
-        with open(allow_list) as f:
+        with Path(allow_list).open() as f:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith("#"):

--- a/ghosttype/pattern_engine.py
+++ b/ghosttype/pattern_engine.py
@@ -14,8 +14,8 @@ not catch. It complements TruffleHog; it does not replace it.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import UTC, datetime
 
 from ghosttype.models import SOURCE_PATTERN, Finding, TextChunk
 from ghosttype.patterns import scan_text
@@ -90,7 +90,7 @@ def scan_chunks(
                     position=f"{chunk.position}:{match.char_offset}",
                     confidence=match.confidence,  # "high" | "medium"
                     context=match.context,
-                    discovered_at=datetime.now(timezone.utc),
+                    discovered_at=datetime.now(UTC),
                     severity=_severity_for(match.secret_type, match.confidence),
                     verified=False,  # pattern matching can never verify
                     detector_name="",

--- a/ghosttype/patterns.py
+++ b/ghosttype/patterns.py
@@ -64,17 +64,17 @@ _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     # GitHub refresh tokens
     ("github_refresh_token", re.compile(r"\b(ghr_[a-zA-Z0-9]{76})\b")),
     # GCP API keys (browser/server keys)
-    ("gcp_api_key",         re.compile(r"\b(AIzaSy[a-zA-Z0-9_-]{33})\b")),
+    ("gcp_api_key", re.compile(r"\b(AIzaSy[a-zA-Z0-9_-]{33})\b")),
     # AWS STS temporary tokens (ASIA prefix)
-    ("aws_sts_token",       re.compile(r"(?<![A-Z0-9])(ASIA[0-9A-Z]{16})(?![A-Z0-9])")),
+    ("aws_sts_token", re.compile(r"(?<![A-Z0-9])(ASIA[0-9A-Z]{16})(?![A-Z0-9])")),
     # Docker Hub personal access tokens
-    ("dockerhub_token",     re.compile(r"\b(dckr_pat_[a-zA-Z0-9_-]{20,})\b")),
+    ("dockerhub_token", re.compile(r"\b(dckr_pat_[a-zA-Z0-9_-]{20,})\b")),
     # Pulumi access tokens
-    ("pulumi_token",        re.compile(r"\b(pul-[a-zA-Z0-9]{40})\b")),
+    ("pulumi_token", re.compile(r"\b(pul-[a-zA-Z0-9]{40})\b")),
     # Doppler service tokens
-    ("doppler_token",       re.compile(r"\b(dp\.st\.[a-zA-Z0-9]{43})\b")),
+    ("doppler_token", re.compile(r"\b(dp\.st\.[a-zA-Z0-9]{43})\b")),
     # PyPI API tokens
-    ("pypi_token",          re.compile(r"\b(pypi-[a-zA-Z0-9_-]{100,})\b")),
+    ("pypi_token", re.compile(r"\b(pypi-[a-zA-Z0-9_-]{100,})\b")),
 ]
 
 # Layer 2: variable-name context signals (confidence: medium)

--- a/ghosttype/report.py
+++ b/ghosttype/report.py
@@ -25,6 +25,7 @@ def _secure_opener(path: str, flags: int) -> int:
     os.fchmod(fd, _OWNER_ONLY)
     return fd
 
+
 _FIELDS = [
     "tool",
     "source",
@@ -111,7 +112,7 @@ def write_json(findings: list[Finding], path: Path, redact: bool = False) -> Non
                 [finding_to_dict(f, redact=redact) for f in findings], indent=2
             )
         )
-    os.chmod(path, _OWNER_ONLY)
+    Path(path).chmod(_OWNER_ONLY)
 
 
 def write_csv(findings: list[Finding], path: Path, redact: bool = False) -> None:
@@ -126,7 +127,7 @@ def write_csv(findings: list[Finding], path: Path, redact: bool = False) -> None
             row = finding_to_dict(f, redact=redact)
             row["extra_data"] = json.dumps(row.get("extra_data") or {}, sort_keys=True)
             writer.writerow(row)
-    os.chmod(path, _OWNER_ONLY)
+    Path(path).chmod(_OWNER_ONLY)
 
 
 def copy_sources(findings: list[Finding], sources_dir: Path) -> None:

--- a/ghosttype/scanner.py
+++ b/ghosttype/scanner.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
-from ghosttype.models import ConversationRecord, Finding, SOURCE_TRUFFLEHOG
-from ghosttype.scanners.base import Scanner
 from ghosttype import pattern_engine
+from ghosttype.models import SOURCE_TRUFFLEHOG, ConversationRecord, Finding
+from ghosttype.scanners.base import Scanner
 from ghosttype.trufflehog_engine import (
     DEFAULT_CONTEXT_WINDOW,
     DEFAULT_TIMEOUT_SECONDS,
+)
+from ghosttype.trufflehog_engine import (
     scan_chunks as trufflehog_scan_chunks,
 )
 
@@ -135,7 +137,7 @@ class Orchestrator:
         self.chunks_scanned = 0
         cutoff: datetime | None = None
         if self._max_age_days is not None:
-            cutoff = datetime.now(timezone.utc) - timedelta(days=self._max_age_days)
+            cutoff = datetime.now(UTC) - timedelta(days=self._max_age_days)
 
         for scanner in self._scanners:
             if tool_filter and scanner.name != tool_filter:

--- a/ghosttype/scanners/__init__.py
+++ b/ghosttype/scanners/__init__.py
@@ -1,8 +1,8 @@
-from ghosttype.scanners.claude_code import ClaudeCodeScanner
-from ghosttype.scanners.cursor import CursorScanner
-from ghosttype.scanners.codex import CodexScanner
 from ghosttype.scanners.chatgpt import ChatGPTScanner
 from ghosttype.scanners.claude import ClaudeScanner
+from ghosttype.scanners.claude_code import ClaudeCodeScanner
+from ghosttype.scanners.codex import CodexScanner
+from ghosttype.scanners.cursor import CursorScanner
 
 SCANNERS = [
     ClaudeCodeScanner(),

--- a/ghosttype/scanners/chatgpt.py
+++ b/ghosttype/scanners/chatgpt.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from ghosttype.models import ConversationRecord, TextChunk
@@ -36,7 +36,7 @@ class ChatGPTScanner(Scanner):
                 source_path=data_file,
                 tool=self.name,
                 conversation_id=data_file.stem,
-                created_at=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+                created_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
                 raw=None,
             ))
         return records
@@ -51,7 +51,7 @@ class ChatGPTScanner(Scanner):
                 )
                 if result.returncode == 0 and result.stdout.strip():
                     return result.stdout.strip().encode()
-            except (subprocess.TimeoutExpired, FileNotFoundError):
+            except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError, OSError):
                 continue
         return None
 
@@ -77,8 +77,9 @@ class ChatGPTScanner(Scanner):
 
         try:
             from hashlib import pbkdf2_hmac
-            from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
             from cryptography.hazmat.primitives import padding as sym_padding
+            from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
             key = pbkdf2_hmac("sha1", key_bytes, b"saltysalt", 1003, dklen=16)
             iv = b" " * 16

--- a/ghosttype/scanners/claude_code.py
+++ b/ghosttype/scanners/claude_code.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -132,7 +132,7 @@ class ClaudeCodeScanner(Scanner):
                         tool=self.name,
                         conversation_id=jsonl_path.stem,
                         created_at=datetime.fromtimestamp(
-                            jsonl_path.stat().st_mtime, tz=timezone.utc
+                            jsonl_path.stat().st_mtime, tz=UTC
                         ),
                         raw=None,
                     )
@@ -146,7 +146,7 @@ class ClaudeCodeScanner(Scanner):
                 tool=self.name,
                 conversation_id="history",
                 created_at=datetime.fromtimestamp(
-                    history_path.stat().st_mtime, tz=timezone.utc
+                    history_path.stat().st_mtime, tz=UTC
                 ),
                 raw={"source_type": "history"},
             ))
@@ -160,7 +160,7 @@ class ClaudeCodeScanner(Scanner):
                     tool=self.name,
                     conversation_id=task_file.stem,
                     created_at=datetime.fromtimestamp(
-                        task_file.stat().st_mtime, tz=timezone.utc
+                        task_file.stat().st_mtime, tz=UTC
                     ),
                     raw={"source_type": "task"},
                 ))
@@ -174,10 +174,9 @@ class ClaudeCodeScanner(Scanner):
 
         if source_type == "history":
             return self._extract_history(record)
-        elif source_type == "task":
+        if source_type == "task":
             return self._extract_task(record)
-        else:
-            return self._extract_session(record)
+        return self._extract_session(record)
 
     def _extract_session(self, record: ConversationRecord) -> list[TextChunk]:
         """Extract text-bearing content from every record type that can carry

--- a/ghosttype/scanners/codex.py
+++ b/ghosttype/scanners/codex.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 from contextlib import closing
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from ghosttype.models import ConversationRecord, TextChunk
@@ -49,7 +49,7 @@ class CodexScanner(Scanner):
 
         for thread_id, title, first_msg, created_ts in rows:
             created_at = (
-                datetime.fromtimestamp(created_ts, tz=timezone.utc)
+                datetime.fromtimestamp(created_ts, tz=UTC)
                 if created_ts
                 else None
             )

--- a/ghosttype/scanners/cursor.py
+++ b/ghosttype/scanners/cursor.py
@@ -4,7 +4,7 @@ import json
 import logging
 import sqlite3
 from contextlib import closing
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from ghosttype.models import ConversationRecord, TextChunk
@@ -80,7 +80,7 @@ class CursorScanner(Scanner):
             composer_id = data.get("composerId", key.split(":", 1)[-1])
             created_ms = data.get("createdAt")
             created_at = (
-                datetime.fromtimestamp(created_ms / 1000, tz=timezone.utc)
+                datetime.fromtimestamp(created_ms / 1000, tz=UTC)
                 if created_ms
                 else None
             )

--- a/ghosttype/trufflehog_engine.py
+++ b/ghosttype/trufflehog_engine.py
@@ -19,9 +19,9 @@ import re
 import shutil
 import subprocess
 import tempfile
-from datetime import datetime, timezone
+from collections.abc import Sequence
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Sequence
 
 from ghosttype.models import ConversationRecord, Finding, TextChunk
 
@@ -327,7 +327,7 @@ def scan_chunks(
                     position=position,
                     confidence="verified" if verified else "unverified",
                     context=context,
-                    discovered_at=datetime.now(timezone.utc),
+                    discovered_at=datetime.now(UTC),
                     severity=_severity_for(detector_lower, verified),
                     verified=verified,
                     detector_name=detector_name,

--- a/tests/scanners/test_chatgpt.py
+++ b/tests/scanners/test_chatgpt.py
@@ -1,8 +1,6 @@
 from pathlib import Path
-from datetime import datetime, timezone
 
 import pytest
-
 from ghosttype.scanners.chatgpt import ChatGPTScanner
 
 

--- a/tests/scanners/test_claude.py
+++ b/tests/scanners/test_claude.py
@@ -1,4 +1,5 @@
-from pathlib import Path
+from datetime import UTC
+
 from ghosttype.scanners.claude import ClaudeScanner
 
 
@@ -20,14 +21,15 @@ def test_claude_scanner_is_available_returns_false_even_when_dir_exists(tmp_path
 
 
 def test_claude_scanner_extract_text_returns_empty(tmp_path, monkeypatch):
+    from datetime import datetime
+
     from ghosttype.models import ConversationRecord
-    from datetime import datetime, timezone
     s = ClaudeScanner()
     rec = ConversationRecord(
         source_path=tmp_path / "placeholder",
         tool="claude",
         conversation_id="stub",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw={},
     )
     assert s.extract_text(rec) == []

--- a/tests/scanners/test_claude_code.py
+++ b/tests/scanners/test_claude_code.py
@@ -1,5 +1,6 @@
+from datetime import UTC
 from pathlib import Path
-import pytest
+
 from ghosttype.scanners.claude_code import ClaudeCodeScanner
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "sample_conversation.jsonl"
@@ -30,14 +31,15 @@ def test_discover_finds_jsonl_files(tmp_path, monkeypatch):
 
 
 def test_extract_text_from_string_content():
+    from datetime import datetime
+
     from ghosttype.models import ConversationRecord
-    from datetime import datetime, timezone
     s = ClaudeCodeScanner()
     rec = ConversationRecord(
         source_path=FIXTURE,
         tool="claude_code",
         conversation_id="sess-1",
-        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
         raw=None,
     )
     chunks = s.extract_text(rec)
@@ -46,14 +48,15 @@ def test_extract_text_from_string_content():
 
 
 def test_extract_text_from_content_block_array():
+    from datetime import datetime
+
     from ghosttype.models import ConversationRecord
-    from datetime import datetime, timezone
     s = ClaudeCodeScanner()
     rec = ConversationRecord(
         source_path=FIXTURE,
         tool="claude_code",
         conversation_id="sess-1",
-        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
         raw=None,
     )
     chunks = s.extract_text(rec)
@@ -63,14 +66,15 @@ def test_extract_text_from_content_block_array():
 
 
 def test_extract_text_position_is_line_number():
+    from datetime import datetime
+
     from ghosttype.models import ConversationRecord
-    from datetime import datetime, timezone
     s = ClaudeCodeScanner()
     rec = ConversationRecord(
         source_path=FIXTURE,
         tool="claude_code",
         conversation_id="sess-1",
-        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
         raw=None,
     )
     chunks = s.extract_text(rec)
@@ -91,8 +95,9 @@ def test_discover_includes_history_jsonl(tmp_path, monkeypatch):
 def test_extract_text_from_history(tmp_path):
     """History entries with display text are extracted; slash commands are skipped."""
     import json
+    from datetime import datetime
+
     from ghosttype.models import ConversationRecord
-    from datetime import datetime, timezone
 
     history = tmp_path / "history.jsonl"
     lines = [
@@ -107,7 +112,7 @@ def test_extract_text_from_history(tmp_path):
         source_path=history,
         tool="claude_code",
         conversation_id="history",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw={"source_type": "history"},
     )
     chunks = s.extract_text(rec)
@@ -135,8 +140,9 @@ def test_discover_includes_task_json_files(tmp_path, monkeypatch):
 def test_extract_text_from_task_json(tmp_path):
     """String values are recursively extracted from task JSON."""
     import json
+    from datetime import datetime
+
     from ghosttype.models import ConversationRecord
-    from datetime import datetime, timezone
 
     task_file = tmp_path / "task-xyz.json"
     task_data = {
@@ -151,7 +157,7 @@ def test_extract_text_from_task_json(tmp_path):
         source_path=task_file,
         tool="claude_code",
         conversation_id="task-xyz",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw={"source_type": "task"},
     )
     chunks = s.extract_text(rec)
@@ -170,8 +176,9 @@ def test_extract_text_from_task_json(tmp_path):
 def _make_session(tmp_path, lines):
     """Helper: write a JSONL session file and return a discover record for it."""
     import json
+    from datetime import datetime
+
     from ghosttype.models import ConversationRecord
-    from datetime import datetime, timezone
 
     path = tmp_path / "audit-session.jsonl"
     path.write_text("\n".join(json.dumps(l) for l in lines) + "\n")
@@ -179,7 +186,7 @@ def _make_session(tmp_path, lines):
         source_path=path,
         tool="claude_code",
         conversation_id="audit",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw=None,
     )
 

--- a/tests/scanners/test_claude_code_resilience.py
+++ b/tests/scanners/test_claude_code_resilience.py
@@ -7,10 +7,8 @@ Every assertion checks an observable outcome.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-
-import pytest
 
 from ghosttype.models import ConversationRecord
 from ghosttype.scanners.claude_code import (
@@ -24,7 +22,7 @@ def _session_rec(path: Path) -> ConversationRecord:
         source_path=path,
         tool="claude_code",
         conversation_id=path.stem,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw=None,
     )
 
@@ -103,7 +101,7 @@ def test_history_skips_blank_malformed_slash_and_short(tmp_path):
     )
     rec = ConversationRecord(
         source_path=p, tool="claude_code", conversation_id="history",
-        created_at=datetime.now(timezone.utc), raw={"source_type": "history"},
+        created_at=datetime.now(UTC), raw={"source_type": "history"},
     )
     chunks = ClaudeCodeScanner().extract_text(rec)
     assert len(chunks) == 1
@@ -117,7 +115,7 @@ def test_history_unreadable_is_logged_not_raised(tmp_path, caplog):
     d.mkdir()
     rec = ConversationRecord(
         source_path=d, tool="claude_code", conversation_id="history",
-        created_at=datetime.now(timezone.utc), raw={"source_type": "history"},
+        created_at=datetime.now(UTC), raw={"source_type": "history"},
     )
     with caplog.at_level(logging.WARNING):
         assert ClaudeCodeScanner().extract_text(rec) == []
@@ -133,7 +131,7 @@ def test_task_malformed_json_is_logged_not_raised(tmp_path, caplog):
     p.write_text("{ not valid json ")
     rec = ConversationRecord(
         source_path=p, tool="claude_code", conversation_id="t",
-        created_at=datetime.now(timezone.utc), raw={"source_type": "task"},
+        created_at=datetime.now(UTC), raw={"source_type": "task"},
     )
     with caplog.at_level(logging.WARNING):
         assert ClaudeCodeScanner().extract_text(rec) == []
@@ -214,7 +212,7 @@ def test_task_with_only_short_strings_yields_no_chunk(tmp_path):
     p.write_text(json.dumps({"a": "x", "b": "y", "n": 1}))
     rec = ConversationRecord(
         source_path=p, tool="claude_code", conversation_id="t",
-        created_at=datetime.now(timezone.utc), raw={"source_type": "task"},
+        created_at=datetime.now(UTC), raw={"source_type": "task"},
     )
     assert ClaudeCodeScanner().extract_text(rec) == []
 

--- a/tests/scanners/test_codex.py
+++ b/tests/scanners/test_codex.py
@@ -1,10 +1,8 @@
 import sqlite3
 from contextlib import closing
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-
 from ghosttype.scanners.codex import CodexScanner
 
 

--- a/tests/scanners/test_cursor.py
+++ b/tests/scanners/test_cursor.py
@@ -1,11 +1,9 @@
 import json
 import sqlite3
 from contextlib import closing
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-
 from ghosttype.scanners.cursor import CursorScanner
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,12 @@
 """CLI tests: the engine and orchestrator are mocked so we don't shell out."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
 from click.testing import CliRunner
-
-from ghosttype.cli import cli, VERSION
+from ghosttype.cli import VERSION, cli
 from ghosttype.models import Finding
 
 
@@ -20,7 +19,7 @@ def _make_finding(tmp_path: Path, *, verified: bool = False) -> Finding:
         position="line:1",
         confidence="verified" if verified else "unverified",
         context="ghp_xxx",
-        discovered_at=datetime.now(timezone.utc),
+        discovered_at=datetime.now(UTC),
         severity="critical" if verified else "high",
         verified=verified,
         detector_name="Github",
@@ -336,7 +335,6 @@ def test_scan_only_verified_alone_still_works(tmp_path, monkeypatch):
 def test_engine_build_argv_rejects_no_verify_with_only_verified():
     """Defense-in-depth for programmatic callers that bypass the CLI guard."""
     import pytest
-
     from ghosttype.trufflehog_engine import _build_argv
 
     with pytest.raises(ValueError, match="incompatible"):

--- a/tests/test_coverage_behaviors.py
+++ b/tests/test_coverage_behaviors.py
@@ -6,28 +6,25 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
-
 from ghosttype import pattern_engine
 from ghosttype.cli import cli
 from ghosttype.models import (
-    ConversationRecord,
-    Finding,
     SOURCE_PATTERN,
     SOURCE_TRUFFLEHOG,
+    ConversationRecord,
+    Finding,
     TextChunk,
 )
 from ghosttype.scanner import Orchestrator
 
-
 # ---------------------------------------------------------------------------
 # pattern_engine
 # ---------------------------------------------------------------------------
+
 
 def _rec(tmp_path) -> ConversationRecord:
     p = tmp_path / "s.jsonl"
@@ -36,7 +33,7 @@ def _rec(tmp_path) -> ConversationRecord:
         source_path=p,
         tool="claude_code",
         conversation_id="c1",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw=None,
     )
 
@@ -121,9 +118,8 @@ def test_orchestrator_skips_scanner_whose_discover_raises(caplog):
     s.discover.side_effect = RuntimeError("disk gone")
     with patch("ghosttype.scanner.trufflehog_scan_chunks", return_value=[]), patch(
         "ghosttype.pattern_engine.scan_chunks", return_value=[]
-    ):
-        with caplog.at_level(logging.WARNING):
-            findings = Orchestrator(scanners=[s]).run()
+    ), caplog.at_level(logging.WARNING):
+        findings = Orchestrator(scanners=[s]).run()
     assert findings == []
     assert "failed during discover" in caplog.text
 
@@ -135,7 +131,7 @@ def test_orchestrator_continues_when_one_records_extract_raises(tmp_path, caplog
         source_path=tmp_path / "bad.jsonl",
         tool="fake",
         conversation_id="bad",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw=None,
     )
     (tmp_path / "bad.jsonl").write_text("x")
@@ -155,9 +151,8 @@ def test_orchestrator_continues_when_one_records_extract_raises(tmp_path, caplog
 
     with patch("ghosttype.scanner.trufflehog_scan_chunks", side_effect=fake_engine), patch(
         "ghosttype.pattern_engine.scan_chunks", return_value=[]
-    ):
-        with caplog.at_level(logging.WARNING):
-            Orchestrator(scanners=[s]).run()
+    ), caplog.at_level(logging.WARNING):
+        Orchestrator(scanners=[s]).run()
     assert "failed extracting" in caplog.text
     # the good record's chunk still reached the engine
     assert len(captured["chunks"]) == 1
@@ -169,9 +164,8 @@ def test_orchestrator_verbose_logs_when_no_chunks(tmp_path, caplog):
     s.extract_text.return_value = []  # discovered but nothing extractable
     with patch("ghosttype.scanner.trufflehog_scan_chunks") as eng, patch(
         "ghosttype.pattern_engine.scan_chunks"
-    ):
-        with caplog.at_level(logging.INFO):
-            Orchestrator(scanners=[s], verbose=True).run()
+    ), caplog.at_level(logging.INFO):
+        Orchestrator(scanners=[s], verbose=True).run()
     eng.assert_not_called()
     assert "extracted 0 text chunks" in caplog.text
 
@@ -186,20 +180,19 @@ def test_orchestrator_verbose_logs_engine_and_dedup_counts(tmp_path, caplog):
     shared = Finding(
         tool="fake", secret_type="github", secret_value="dup",
         file_path=rec.source_path, position="l:1", confidence="unverified",
-        context="dup", discovered_at=datetime.now(timezone.utc),
+        context="dup", discovered_at=datetime.now(UTC),
         source=SOURCE_TRUFFLEHOG,
     )
     pat_dup = Finding(
         tool="fake", secret_type="github_pat_classic", secret_value="dup",
         file_path=rec.source_path, position="l:1:0", confidence="high",
-        context="dup", discovered_at=datetime.now(timezone.utc),
+        context="dup", discovered_at=datetime.now(UTC),
         source=SOURCE_PATTERN,
     )
     with patch("ghosttype.scanner.trufflehog_scan_chunks", return_value=[shared]), patch(
         "ghosttype.pattern_engine.scan_chunks", return_value=[pat_dup]
-    ):
-        with caplog.at_level(logging.INFO):
-            findings = Orchestrator(scanners=[s], verbose=True, engine="both").run()
+    ), caplog.at_level(logging.INFO):
+        findings = Orchestrator(scanners=[s], verbose=True, engine="both").run()
     # overlap on (value,file) -> TruffleHog kept, pattern shadowed
     assert len(findings) == 1
     assert findings[0].source == SOURCE_TRUFFLEHOG
@@ -215,7 +208,7 @@ def _finding(tmp_path, **kw) -> Finding:
         tool="claude_code", secret_type="github", secret_value="ghp_v",
         file_path=tmp_path / "s.jsonl", position="line:1",
         confidence="unverified", context="ghp_v",
-        discovered_at=datetime.now(timezone.utc), verified=False,
+        discovered_at=datetime.now(UTC), verified=False,
         detector_name="Github", source=SOURCE_TRUFFLEHOG,
     )
     base.update(kw)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,14 +22,13 @@ import shutil
 import sqlite3
 from contextlib import closing
 from pathlib import Path
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
 import pytest
-
+from ghosttype.report import write_csv, write_json
+from ghosttype.scanner import Orchestrator
 from ghosttype.scanners.claude_code import ClaudeCodeScanner
 from ghosttype.scanners.cursor import CursorScanner
-from ghosttype.scanner import Orchestrator
-from ghosttype.report import write_csv, write_json
 
 requires_trufflehog = pytest.mark.skipif(
     shutil.which("trufflehog") is None,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from ghosttype.models import ConversationRecord, TextChunk, Finding
+
+from ghosttype.models import ConversationRecord, Finding, TextChunk
 
 
 def test_conversation_record_fields():
@@ -8,7 +9,7 @@ def test_conversation_record_fields():
         source_path=Path("/tmp/test.jsonl"),
         tool="claude_code",
         conversation_id="abc-123",
-        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
         raw={"messages": []},
     )
     assert rec.tool == "claude_code"
@@ -28,7 +29,7 @@ def test_text_chunk_back_reference():
 
 
 def test_finding_default_fields():
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     f = Finding(
         tool="cursor",
         secret_type="github",
@@ -46,7 +47,7 @@ def test_finding_default_fields():
 
 
 def test_finding_verified_fields():
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     f = Finding(
         tool="claude_code",
         secret_type="aws",

--- a/tests/test_patterns_filters.py
+++ b/tests/test_patterns_filters.py
@@ -80,7 +80,7 @@ def test_heuristic_placeholder_is_filtered_but_real_value_reported():
     """A heuristic var-name signal with a placeholder value is dropped; the
     same signal with a high-entropy value is kept."""
     dropped = scan_text("api_key = your-key-here")
-    assert all("your-key-here" != m.secret_value for m in dropped)
+    assert all(m.secret_value != "your-key-here" for m in dropped)
 
     kept = scan_text("api_key = Zx9Q2mK7vL4pW1aB3cD5eF8gH0jR6tY")
     assert any(m.secret_value == "Zx9Q2mK7vL4pW1aB3cD5eF8gH0jR6tY" for m in kept)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,10 +1,8 @@
 import csv
 import json
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import UTC, datetime
 
 import pytest
-
 from ghosttype.models import Finding
 from ghosttype.report import copy_sources, write_csv, write_json
 
@@ -13,7 +11,7 @@ from ghosttype.report import copy_sources, write_csv, write_json
 def findings(tmp_path):
     src = tmp_path / "session.jsonl"
     src.write_text('{"type":"user","message":{"content":"hi"}}\n')
-    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     return [
         Finding(
             tool="claude_code",

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2,17 +2,15 @@
 trufflehog or run the real regex engine in unit tests."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from ghosttype.models import (
-    ConversationRecord,
-    Finding,
     SOURCE_PATTERN,
     SOURCE_TRUFFLEHOG,
+    ConversationRecord,
+    Finding,
     TextChunk,
 )
 from ghosttype.scanner import Orchestrator
@@ -26,7 +24,7 @@ def mock_scanner(tmp_path):
         source_path=src,
         tool="fake_tool",
         conversation_id="conv-1",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw={},
     )
     chunk = TextChunk(text="GITHUB_TOKEN=ghp_xxx", position="line:1", record=rec)
@@ -47,7 +45,7 @@ def _th_finding(tool, value, source_path, verified=False) -> Finding:
         position="line:1",
         confidence="verified" if verified else "unverified",
         context=value,
-        discovered_at=datetime.now(timezone.utc),
+        discovered_at=datetime.now(UTC),
         severity="critical" if verified else "high",
         verified=verified,
         detector_name="Github",
@@ -64,7 +62,7 @@ def _pat_finding(tool, value, source_path, secret_type="github_pat_classic") -> 
         position="line:1:0",
         confidence="high",
         context=value,
-        discovered_at=datetime.now(timezone.utc),
+        discovered_at=datetime.now(UTC),
         severity="critical",
         verified=False,
         detector_name="",
@@ -151,7 +149,7 @@ def test_orchestrator_max_age_filter(mock_scanner, tmp_path):
         source_path=tmp_path / "old.jsonl",
         tool="fake_tool",
         conversation_id="old",
-        created_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        created_at=datetime(2020, 1, 1, tzinfo=UTC),
         raw={},
     )
     (tmp_path / "old.jsonl").write_text("x")

--- a/tests/test_scanner_coverage.py
+++ b/tests/test_scanner_coverage.py
@@ -11,24 +11,23 @@ import json
 import logging
 import sqlite3
 from contextlib import closing
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import PropertyMock, patch
 
 import pytest
-
 from ghosttype.models import ConversationRecord, Finding
+from ghosttype.report import copy_sources
+from ghosttype.scanner import Orchestrator
 from ghosttype.scanners.base import Scanner
 from ghosttype.scanners.claude import ClaudeScanner
 from ghosttype.scanners.codex import CodexScanner
 from ghosttype.scanners.cursor import CursorScanner
-from ghosttype.scanner import Orchestrator
-from ghosttype.report import copy_sources
-
 
 # ---------------------------------------------------------------------------
 # CursorScanner
 # ---------------------------------------------------------------------------
+
 
 def _cursor_db(path: Path, rows: list[tuple[str, str]]) -> None:
     with closing(sqlite3.connect(path)) as conn:
@@ -66,9 +65,8 @@ def test_cursor_corrupt_db_is_logged_not_raised(tmp_path, caplog):
     bad.write_text("this is not a sqlite file")
     s = CursorScanner()
     with patch.object(type(s), "_db_path", new_callable=PropertyMock, return_value=bad), \
-         patch.object(type(s), "_workspace_dbs", return_value=[]):
-        with caplog.at_level(logging.WARNING):
-            assert s.discover() == []
+         patch.object(type(s), "_workspace_dbs", return_value=[]), caplog.at_level(logging.WARNING):
+        assert s.discover() == []
     assert "Failed to read cursor db" in caplog.text
 
 
@@ -81,9 +79,8 @@ def test_cursor_workspace_db_without_composer_table_is_skipped(tmp_path, caplog)
         conn.commit()
     s = CursorScanner()
     with patch.object(type(s), "_db_path", new_callable=PropertyMock, return_value=db), \
-         patch.object(type(s), "_workspace_dbs", return_value=[]):
-        with caplog.at_level(logging.DEBUG):
-            assert s.discover() == []
+         patch.object(type(s), "_workspace_dbs", return_value=[]), caplog.at_level(logging.DEBUG):
+        assert s.discover() == []
     assert "no cursorDiskKV table" in caplog.text
 
 
@@ -239,7 +236,7 @@ def test_claude_stub_discover_and_extract_return_empty(tmp_path):
     s = ClaudeScanner()
     rec = ConversationRecord(
         source_path=tmp_path / "x", tool="claude", conversation_id="s",
-        created_at=datetime.now(timezone.utc), raw={},
+        created_at=datetime.now(UTC), raw={},
     )
     assert s.discover() == []
     assert s.extract_text(rec) == []
@@ -256,7 +253,7 @@ def test_copy_sources_skips_finding_whose_source_file_is_gone(tmp_path):
     f = Finding(
         tool="claude_code", secret_type="github", secret_value="x",
         file_path=gone, position="line:1", confidence="unverified",
-        context="x", discovered_at=datetime.now(timezone.utc),
+        context="x", discovered_at=datetime.now(UTC),
     )
     out = tmp_path / "sources"
     copy_sources([f], out)  # must not raise
@@ -289,15 +286,14 @@ def test_orchestrator_non_verbose_zero_chunks_is_silent(tmp_path, caplog):
     s.is_available.return_value = True
     rec = ConversationRecord(
         source_path=tmp_path / "s.jsonl", tool="fake", conversation_id="c",
-        created_at=datetime.now(timezone.utc), raw=None,
+        created_at=datetime.now(UTC), raw=None,
     )
     (tmp_path / "s.jsonl").write_text("x")
     s.discover.return_value = [rec]
     s.extract_text.return_value = []
     with patch("ghosttype.scanner.trufflehog_scan_chunks") as eng, \
-         patch("ghosttype.pattern_engine.scan_chunks"):
-        with caplog.at_level(logging.INFO):
-            findings = Orchestrator(scanners=[s], verbose=False).run()
+         patch("ghosttype.pattern_engine.scan_chunks"), caplog.at_level(logging.INFO):
+        findings = Orchestrator(scanners=[s], verbose=False).run()
     eng.assert_not_called()
     assert findings == []
     assert "extracted 0 text chunks" not in caplog.text

--- a/tests/test_trufflehog_engine.py
+++ b/tests/test_trufflehog_engine.py
@@ -7,12 +7,11 @@ tests/test_integration.py.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-
 from ghosttype import trufflehog_engine as te
 from ghosttype.models import ConversationRecord, TextChunk
 
@@ -25,7 +24,7 @@ def fake_record(tmp_path):
         source_path=src,
         tool="claude_code",
         conversation_id="conv-abc",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         raw={},
     )
 
@@ -78,9 +77,8 @@ def test_resolve_binary_env_override(monkeypatch):
 
 def test_resolve_binary_raises_when_missing(monkeypatch):
     monkeypatch.delenv("GHOSTTYPE_TRUFFLEHOG_BIN", raising=False)
-    with _which_returns(None):
-        with pytest.raises(te.TruffleHogNotFoundError):
-            te.resolve_binary()
+    with _which_returns(None), pytest.raises(te.TruffleHogNotFoundError):
+        te.resolve_binary()
 
 
 def test_scan_chunks_empty_returns_empty():
@@ -305,13 +303,12 @@ def test_scan_chunks_returns_empty_when_all_chunks_blank(fake_record):
         TextChunk(text="", position="line:1", record=fake_record),
         TextChunk(text="  ", position="line:2", record=fake_record),
     ]
-    with _which_returns("/usr/local/bin/trufflehog"):
-        with patch(
-            "ghosttype.trufflehog_engine.subprocess.run"
-        ) as run_mock:
-            findings = te.scan_chunks(
-                "claude_code", chunks, binary="/usr/local/bin/trufflehog"
-            )
+    with _which_returns("/usr/local/bin/trufflehog"), patch(
+        "ghosttype.trufflehog_engine.subprocess.run"
+    ) as run_mock:
+        findings = te.scan_chunks(
+            "claude_code", chunks, binary="/usr/local/bin/trufflehog"
+        )
     assert findings == []
     run_mock.assert_not_called()
 


### PR DESCRIPTION
## Summary

Our analysis found **26 format issues** and about **38 refactoring opportunities** across the reviewed scope. Bandit reported no high-severity Python security patterns; duplication is below threshold; maintainability index looks good, but several functions have high cyclomatic complexity (notably `scan` in `cli.py` and `scan_chunks` in `trufflehog_engine.py`); gitleaks flagged credential-shaped strings in fixtures and the pattern catalog (expected for a credential scanner). This pull request is a **sample** of those findings — **26 files, ~286 line changes** — not a full format pass or refactor cleanup.

Hotspots and improvement notes below are scoped to **Python (`*.py`)** source.

## What you are doing right

- No high-severity Bandit findings in shipped Python code (bandit.scan passed).
- Python code duplication is below the jscpd threshold — no meaningful clone pairs flagged.
- Maintainability index (radon.mi) passed for all modules in scope.
- Dead-code scanners (vulture, deadcode) reported no unused symbols in the package tree.
- pip-audit reported no known vulnerabilities in the pinned runtime closure.

## What you could improve

### Duplicate code

No significant duplicate Python blocks above the jscpd threshold were reported.

## Changes

- Apply ruff-driven formatting across `ghosttype/` and `tests/` (import order, UTC alias, spacing, test `with` consolidation).
- Catch `PermissionError` and `OSError` in `ChatGPTScanner._get_keychain_key` so Linux/WSL environments degrade gracefully when the `security` binary is present but unusable.
