### PR TITLE
ci: align codeql-action/init and analyze to v4.37.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,12 @@ jobs:
           python-version: "3.11"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: python
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # Opengrep (OSS LGPL-2.1 fork of the Semgrep engine) second-opinion SAST.
       # No blanket suppression: the ONE documented exception is the forensic


### PR DESCRIPTION
## Summary

Fixes the `JOB_STATUS_CONFIGURATION_ERROR` CodeQL SAST failures on PRs #36 and #38.

**Root cause:** Dependabot opened separate PRs for `codeql-action/init` and `codeql-action/analyze`. After PR #40 merged `upload-sarif` to v4.37.3, `main` had a partially-upgraded state. Each Dependabot PR individually created a version mismatch: `init` writes a config file tagged with its version, and `analyze` must be the exact same version to read it.

- PR #36 errors: `Loaded a configuration file for version '4.37.3', but running version '4.37.0'` (init=4.37.3, analyze=4.37.0)
- PR #38 errors: `Loaded a configuration file for version '4.37.0', but running version '4.37.3'` (init=4.37.0, analyze=4.37.3)

**Fix:** Bump both `codeql-action/init` and `codeql-action/analyze` atomically to the same SHA (`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` / v4.37.3), matching the already-merged `upload-sarif` pin.

Closes #36
Closes #38

---
_Generated by [Claude Code](https://claude.ai/code/session_019zr6ArrLGmpNQ3CnzNi1GJ)_