### PR TITLE
deps: bump github/codeql-action init+analyze from 4.37.7 to 4.37.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,12 @@ jobs:
           python-version: "3.11"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       # Opengrep (OSS LGPL-2.1 fork of the Semgrep engine) second-opinion SAST.
       # No blanket suppression: the ONE documented exception is the forensic


### PR DESCRIPTION
Combines dependabot #63 (`init`) and #61 (`analyze`). Supersedes both — they cannot be merged independently.

## Why they had to be combined

`codeql-action` requires `init` and `analyze` to run at the same version. Dependabot opened them as two separate PRs, so each one is red on its own:

```
##[error]analyze post-action step failed: Loaded a configuration file
for version '4.37.7', but running version '4.37.9'
CODEQL_ACTION_JOB_STATUS: JOB_STATUS_CONFIGURATION_ERROR
```

The failure also takes out the Opengrep SARIF upload, which lives in the same `sast` job and never gets its `opengrep.sarif` because the job aborts first (`##[error]Path does not exist: opengrep.sarif`). That is why the `Opengrep OSS` check is missing entirely on #61 and #63 rather than merely failing.

Bumping both refs in one commit is the only way either update lands green.

## Change

```diff
-  uses: github/codeql-action/init@ff2f1c62… # v4.37.7
+  uses: github/codeql-action/init@cdf488f5… # v4.37.9
-  uses: github/codeql-action/analyze@ff2f1c62… # v4.37.7
+  uses: github/codeql-action/analyze@cdf488f5… # v4.37.9
```

Two lines in `.github/workflows/ci.yml`. SHA-pinning is preserved, per the repo's dependabot rationale.

## Provenance of the pin

`cdf488f595d80d6e07e03d4674febd5ab45fa938` is dependabot's own resolved SHA for v4.37.9 — proposed identically and independently in #61, #62 and #63. It is already on `main` for `upload-sarif` via #62, where CI exercised it successfully. This is not a hand-picked SHA.

After this lands, all four `codeql-action` references in the repo are consistent at v4.37.9 and no reference to the old SHA remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZVyXmzL1LTF1uDDiiEc8H

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZVyXmzL1LTF1uDDiiEc8H)_